### PR TITLE
Fix Zoom

### DIFF
--- a/src/com/ortiz/touch/TouchImageView.java
+++ b/src/com/ortiz/touch/TouchImageView.java
@@ -395,6 +395,7 @@ public class TouchImageView extends ImageView {
     	m[Matrix.MTRANS_Y] = -((focusY * getImageHeight()) - (viewHeight * 0.5f));
     	matrix.setValues(m);
     	fixTrans();
+	savePreviousImageValues();
     	setImageMatrix(matrix);
     }
     


### PR DESCRIPTION
Save previous matrix values after zooming to get the right matrix values from prevMatrix when OnMeasure occurs right after it.